### PR TITLE
Implement draft lifecycle and Issue action (#33)

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -3,7 +3,7 @@
 # Invoice controller with search, sort, and filter
 class InvoicesController < ApplicationController # rubocop:disable Metrics/ClassLength
   before_action :authenticate_user!
-  before_action :set_invoice, only: %i[show edit update destroy]
+  before_action :set_invoice, only: %i[show edit update destroy issue]
 
   # GET /invoices or /invoices.json
   def index # rubocop:disable Metrics/AbcSize
@@ -46,6 +46,13 @@ class InvoicesController < ApplicationController # rubocop:disable Metrics/Class
   def create
     @invoice = Invoice.new(invoice_params)
     @invoice.user = current_user
+
+    # Determine status from submit button
+    if params[:save_and_issue].present?
+      @invoice.status = 'pendiente'
+    else
+      @invoice.status = 'borrador'
+    end
 
     respond_to do |format|
       success = Invoice.transaction do
@@ -103,13 +110,49 @@ class InvoicesController < ApplicationController # rubocop:disable Metrics/Class
 
   # DELETE /invoices/1 or /invoices/1.json
   def destroy
-    @invoice.destroy
+    if @invoice.destroy
+      respond_to do |format|
+        format.html do
+          redirect_to invoices_url, notice: I18n.t('factura_borrada')
+        end
+        format.json { head :no_content }
+      end
+    else
+      respond_to do |format|
+        format.html do
+          redirect_to invoices_url, alert: @invoice.errors.full_messages.join(', ')
+        end
+        format.json { render json: @invoice.errors, status: :unprocessable_entity }
+      end
+    end
+  end
 
+  # POST /invoices/:id/issue
+  def issue
+    respond_to do |format|
+      success = Invoice.transaction do
+        @invoice.issue!
+        true
+      end
+
+      if success
+        format.html do
+          redirect_to invoices_path, notice: I18n.t('invoice.issued')
+        end
+        format.json { render :show, status: :ok, location: @invoice }
+      else
+        format.html do
+          redirect_to invoices_path, alert: I18n.t('invoice.issue_failed')
+        end
+        format.json { render json: @invoice.errors, status: :unprocessable_entity }
+      end
+    end
+  rescue StandardError => e
     respond_to do |format|
       format.html do
-        redirect_to invoices_url, notice: I18n.t('factura_borrada')
+        redirect_to invoices_path, alert: e.message
       end
-      format.json { head :no_content }
+      format.json { render json: { error: e.message }, status: :unprocessable_entity }
     end
   end
 
@@ -131,7 +174,6 @@ class InvoicesController < ApplicationController # rubocop:disable Metrics/Class
       :irpf,
       :total,
       :notes,
-      :status,
       line_items_attributes: %i[id item_id invoice_id quantity price iva total _destroy]
     )
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -12,7 +12,10 @@ class Invoice < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   validates :client_id, presence: true
 
-  attribute :status, :string, default: 'pendiente'
+  attribute :status, :string, default: 'borrador'
+
+  STATUSES = %w[borrador pendiente pagada].freeze
+  validates :status, inclusion: { in: STATUSES }
 
   scope :for_account, ->(user_id) { where(user_id:) }
 
@@ -28,6 +31,33 @@ class Invoice < ApplicationRecord # rubocop:disable Metrics/ClassLength
                   },
                   using: { tsearch: { prefix: true } },
                   ignoring: :accents
+
+  def draft?
+    status == 'borrador'
+  end
+
+  def issued?
+    %w[pendiente pagada].include?(status)
+  end
+
+  # Transitions draft to pendiente, reserving the next correlative number atomically.
+  # Must be called inside a transaction.
+  def issue!
+    raise 'Invoice is not a draft' unless draft?
+
+    assign_number_from_default_scope!
+    update!(status: 'pendiente')
+  end
+
+  # Prevents destruction of issued invoices
+  def prevent_destruction_if_issued
+    return if draft?
+
+    errors.add(:base, I18n.t('invoice.destroy_blocked'))
+    throw :abort
+  end
+
+  before_destroy :prevent_destruction_if_issued
 
   def client_full_name
     Client.find(client_id).full_name
@@ -52,6 +82,10 @@ class Invoice < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def self.total_invoice_count
     count
+  end
+
+  def self.total_draft_count
+    filter_status('borrador').count
   end
 
   def self.total_paid_count
@@ -90,8 +124,10 @@ class Invoice < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def status?
     return 'paid' if status == 'pagada'
+    return 'not-paid' if status == 'pendiente'
+    return 'draft' if status == 'borrador'
 
-    'not-paid' if status == 'pendiente'
+    nil
   end
 
   def pdf_line_items

--- a/app/views/invoices/_form.html.erb
+++ b/app/views/invoices/_form.html.erb
@@ -24,7 +24,9 @@
             <%= heroicon "hashtag", options: {class: "w-4 h-4 fill-current text-slate-400 shrink-0" } %>
           </div>
           <% if invoice.new_record? %>
-            <span class="form-input w-full pl-8 text-slate-500"><%= t("numero_asignado_al_guardar") %></span>
+            <span class="form-input w-full pl-8 text-slate-500"><%= t("numero_asignado_al_emitir") %></span>
+          <% elsif invoice.draft? %>
+            <span class="form-input w-full pl-8 text-slate-500"><%= t("Borrador") %></span>
           <% else %>
             <span class="form-input w-full pl-8"><%= invoice.display_number || invoice.invoice_number %></span>
           <% end %>
@@ -91,7 +93,8 @@
     <hr class="mb-5"/>
 
     <div class="inline">
-      <%= f.submit t("guardar_factura"), class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+      <%= f.submit t("guardar_borrador"), name: 'save_draft', class: "rounded-lg py-3 px-5 bg-slate-500 text-white inline-block font-medium cursor-pointer" %>
+      <%= f.submit t("guardar_factura"), name: 'save_and_issue', class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer ml-2" %>
     </div>
   <% end %>
 </div>

--- a/app/views/invoices/_invoice.html.erb
+++ b/app/views/invoices/_invoice.html.erb
@@ -9,7 +9,11 @@
                             </div>
                         </td>
                         <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-                            <div class="font-medium text-sky-500"><%= invoice.display_number || "##{invoice.invoice_number}" %></div>
+                            <% if invoice.draft? %>
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800"><%= t("Borrador") %></span>
+                            <% else %>
+                                <div class="font-medium text-sky-500"><%= invoice.display_number %></div>
+                            <% end %>
                         </td>
                         <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
                             <div class="font-medium text-rose-500"><%= number_to_currency(invoice.total, locale: :es) %></div>
@@ -35,18 +39,27 @@
                                         <path d="M19.7 8.3c-.4-.4-1-.4-1.4 0l-10 10c-.2.2-.3.4-.3.7v4c0 .6.4 1 1 1h4c.3 0 .5-.1.7-.3l10-10c.4-.4.4-1 0-1.4l-4-4zM12.6 22H10v-2.6l6-6 2.6 2.6-6 6zm7.4-7.4L17.4 12l1.6-1.6 2.6 2.6-1.6 1.6z" />
                                     </svg>
                                 <% end %>
-                                <%= link_to invoice_path(invoice, format: :pdf, locale: I18n.locale), class: "text-slate-400 hover:text-slate-500", target: "_blank" do %>
-                                    <span class="sr-only"><%= t("descargar") %></span>
-                                    <svg class="w-8 h-8 fill-current" viewBox="0 0 32 32">
-                                        <path d="M16 20c.3 0 .5-.1.7-.3l5.7-5.7-1.4-1.4-4 4V8h-2v8.6l-4-4L9.6 14l5.7 5.7c.2.2.4.3.7.3zM9 22h14v2H9z" />
-                                    </svg>
-                                <% end %>
-                                <%= button_to invoice, method: :delete, form: { data: { turbo_confirm: t("estas_seguro") } }, class: "text-rose-500 hover:text-rose-600" do %>
-                                    <span class="sr-only"><%= t("eliminar") %></span>
-                                    <svg class="w-8 h-8 fill-current" viewBox="0 0 32 32">
-                                        <path d="M13 15h2v6h-2zM17 15h2v6h-2z" />
-                                        <path d="M20 9c0-.6-.4-1-1-1h-6c-.6 0-1 .4-1 1v2H8v2h1v10c0 .6.4 1 1 1h12c.6 0 1-.4 1-1V13h1v-2h-4V9zm-6 1h4v1h-4v-1zm7 3v9H11v-9h10z" />
-                                    </svg>
+                                <% if invoice.draft? %>
+                                    <%= button_to issue_invoice_path(invoice), method: :post, form: { data: { turbo_confirm: t("confirmar_emision") } }, class: "text-green-500 hover:text-green-600" do %>
+                                        <span class="sr-only"><%= t("emitir") %></span>
+                                        <svg class="w-8 h-8 fill-current" viewBox="0 0 32 32">
+                                            <path d="M16 2C8.3 2 2 8.3 2 16s6.3 14 14 14 14-6.3 14-14S23.7 2 16 2zm6 11.2l-7 7C14.7 20.5 14.3 20.7 14 20.7s-.7-.2-1-.5l-3-3c-.6-.6-.6-1.5 0-2.1s1.5-.6 2.1 0L14 17l6.3-6.3c.6-.6 1.5-.6 2.1 0s.6 1.5 0 2.1z"/>
+                                        </svg>
+                                    <% end %>
+                                    <%= button_to invoice, method: :delete, form: { data: { turbo_confirm: t("estas_seguro") } }, class: "text-rose-500 hover:text-rose-600" do %>
+                                        <span class="sr-only"><%= t("eliminar") %></span>
+                                        <svg class="w-8 h-8 fill-current" viewBox="0 0 32 32">
+                                            <path d="M13 15h2v6h-2zM17 15h2v6h-2z" />
+                                            <path d="M20 9c0-.6-.4-1-1-1h-6c-.6 0-1 .4-1 1v2H8v2h1v10c0 .6.4 1 1 1h12c.6 0 1-.4 1-1V13h1v-2h-4V9zm-6 1h4v1h-4v-1zm7 3v9H11v-9h10z" />
+                                        </svg>
+                                    <% end %>
+                                <% else %>
+                                    <%= link_to invoice_path(invoice, format: :pdf, locale: I18n.locale), class: "text-slate-400 hover:text-slate-500", target: "_blank" do %>
+                                        <span class="sr-only"><%= t("descargar") %></span>
+                                        <svg class="w-8 h-8 fill-current" viewBox="0 0 32 32">
+                                            <path d="M16 20c.3 0 .5-.1.7-.3l5.7-5.7-1.4-1.4-4 4V8h-2v8.6l-4-4L9.6 14l5.7 5.7c.2.2.4.3.7.3zM9 22h14v2H9z" />
+                                        </svg>
+                                    <% end %>
                                 <% end %>
                             </div>
                         </td>

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -69,6 +69,14 @@
                             <%= content_tag :span, Invoice.total_not_paid_count, class: 'ml-1 text-slate-400' %>
                         <% end %>
                     </li>
+                    <li class="m-1">
+                        <% if Invoice.total_draft_count > 0 %>
+                            <%= button_tag(type: 'button', data: { action: 'click->filter#submitForm', value: 'borrador' }, class: params[:status] == 'borrador' ? 'filter-btn-active' : 'filter-btn') do %>
+                                <%= t("borradores") %>
+                                <%= content_tag :span, Invoice.total_draft_count, class: 'ml-1 text-slate-400' %>
+                            <% end %>
+                        <% end %>
+                    </li>
                     <li class="m-1 hidden">
                         <% if Invoice.total_about_to_be_due_count > 0 %>
                             <%= button_tag(type: 'button', data: { action: 'click->filter#submitForm', value: 'por_vencer' }, class: params[:status] == 'por_vencer' ? 'filter-btn-active' : 'filter-btn') do %>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -12,7 +12,11 @@
 
       <p class="my-5">
         <strong class="block font-medium mb-1"><%= t("numero_factura") %>:</strong>
-        <%= @invoice.display_number || @invoice.invoice_number %>
+        <% if @invoice.draft? %>
+          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800"><%= t("Borrador") %></span>
+        <% else %>
+          <%= @invoice.display_number %>
+        <% end %>
       </p>
 
       <p class="my-5">
@@ -36,10 +40,15 @@
       </p>
     </div>
 
+    <% if @invoice.draft? %>
+      <%= button_to t("emitir"), issue_invoice_path(@invoice), method: :post, data: { turbo_confirm: t("confirmar_emision") }, class: "mt-2 rounded-lg py-3 px-5 bg-green-600 text-white inline-block font-medium" %>
+    <% end %>
     <%= link_to t("editar"), edit_invoice_path(@invoice), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-    <div class="inline-block ml-2">
-      <%= button_to t("eliminar"), invoice_path(@invoice), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
-    </div>
+    <% if @invoice.draft? %>
+      <div class="inline-block ml-2">
+        <%= button_to t("eliminar"), invoice_path(@invoice), method: :delete, data: { turbo_confirm: t("estas_seguro") }, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+      </div>
+    <% end %>
     <%= link_to t("volver"), invoices_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
   </div>
 </div>

--- a/config/locales/invoices/en.yml
+++ b/config/locales/invoices/en.yml
@@ -24,6 +24,8 @@ en:
   Pagada: Paid
   pendientes: Pending
   Pendiente: Pending
+  borradores: Drafts
+  Borrador: Draft
   por_vencer: Due Soon
   vencidas: Overdue
   buscar_factura: Search invoice...
@@ -49,6 +51,7 @@ en:
   quitar_item: Remove Item
   items_facturar: Items to Invoice
   guardar_factura: Save Invoice
+  guardar_borrador: Save as Draft
   factura_creada: Invoice created successfully
   factura_borrada: Invoice was successfully deleted
   factura_editada: Invoice was successfully updated
@@ -69,7 +72,12 @@ en:
   editar: Edit
   descargar: Download
   eliminar: Delete
+  emitir: Issue
   numero_asignado_al_guardar: Assigned on save
+  numero_asignado_al_emitir: Assigned on issue
   volver: Back
-  
-  
+  invoice:
+    destroy_blocked: Issued invoices cannot be deleted
+    issued: Invoice has been issued successfully
+    issue_failed: Could not issue the invoice
+  confirmar_emision: Are you sure you want to issue this invoice? This action cannot be undone.

--- a/config/locales/invoices/es.yml
+++ b/config/locales/invoices/es.yml
@@ -24,6 +24,8 @@ es:
   Pagada: Pagada
   pendientes: Pendientes
   Pendiente: Pendiente
+  borradores: Borradores
+  Borrador: Borrador
   por_vencer: Por vencer
   vencidas: Vencidas
   buscar_factura: Buscar factura...
@@ -49,6 +51,7 @@ es:
   quitar_item: Eliminar Ítem
   items_facturar: Ítems a Facturar
   guardar_factura: Guardar Factura
+  guardar_borrador: Guardar como Borrador
   factura_creada: Factura creada exitosamente
   factura_borrada: Factura borrada exitosamente
   factura_editada: Factura editada exitosamente
@@ -69,6 +72,12 @@ es:
   editar: Editar
   descargar: Descargar
   eliminar: Eliminar
+  emitir: Emitir
   numero_asignado_al_guardar: Se asigna al guardar
+  numero_asignado_al_emitir: Se asigna al emitir
   volver: Volver
-
+  invoice:
+    destroy_blocked: Las facturas emitidas no se pueden eliminar
+    issued: La factura ha sido emitida exitosamente
+    issue_failed: No se pudo emitir la factura
+  confirmar_emision: ¿Estás seguro de que quieres emitir esta factura? Esta acción no se puede deshacer.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
   resources :invoices do
     resources :line_items, except: [:index]
     post :add_item, on: :collection
+    member do
+      post :issue
+    end
   end
   resources :after_register
 

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class InvoicesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @invoice = invoices(:one)
+    @draft = invoices(:draft_one)
     sign_in users(:first)
   end
 
@@ -16,10 +17,63 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should create invoice" do
+  test "should create invoice as draft" do
     assert_difference("Invoice.count") do
       post invoices_url,
            params: {
+             save_draft: true,
+             invoice: {
+               date: @invoice.date,
+               due_date: @invoice.due_date,
+               irpf: @invoice.irpf,
+               iva: @invoice.iva,
+               notes: @invoice.notes,
+               subtotal: @invoice.subtotal,
+               total: @invoice.total,
+               client_id: Client.first.id
+             }
+           }
+    end
+
+    assert_redirected_to invoices_url(locale: I18n.locale)
+    created = Invoice.last
+    assert_equal 'borrador', created.status
+    assert_nil created.number
+    assert_nil created.series
+  end
+
+  test "should create invoice as pendiente via save_and_issue" do
+    sequence = invoice_sequences(:default_a_active)
+    original_last = sequence.last_number
+
+    assert_difference("Invoice.count") do
+      post invoices_url,
+           params: {
+             save_and_issue: true,
+             invoice: {
+               date: @invoice.date,
+               due_date: @invoice.due_date,
+               irpf: @invoice.irpf,
+               iva: @invoice.iva,
+               notes: @invoice.notes,
+               subtotal: @invoice.subtotal,
+               total: @invoice.total,
+               client_id: Client.first.id
+             }
+           }
+    end
+
+    assert_redirected_to invoices_url(locale: I18n.locale)
+    created = Invoice.last
+    assert_equal 'pendiente', created.status
+    assert_equal original_last + 1, created.number
+  end
+
+  test "should create invoice (legacy test with status param)" do
+    assert_difference("Invoice.count") do
+      post invoices_url,
+           params: {
+             save_and_issue: true,
              invoice: {
                date: @invoice.date,
                due_date: @invoice.due_date,
@@ -43,10 +97,10 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
 
     post invoices_url,
          params: {
+           save_and_issue: true,
            invoice: {
              date: Date.today,
              due_date: Date.today + 30,
-             status: 'pendiente',
              subtotal: 100,
              iva: 21,
              total: 121,
@@ -67,10 +121,10 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     # First create
     post invoices_url,
          params: {
+           save_and_issue: true,
            invoice: {
              date: Date.today,
              due_date: Date.today + 30,
-             status: 'pendiente',
              subtotal: 100,
              iva: 21,
              total: 121,
@@ -82,10 +136,10 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     # Second create
     post invoices_url,
          params: {
+           save_and_issue: true,
            invoice: {
              date: Date.today,
              due_date: Date.today + 30,
-             status: 'pendiente',
              subtotal: 200,
              iva: 42,
              total: 242,
@@ -96,6 +150,28 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal original_last + 1, first_number
     assert_equal original_last + 2, second_number
+  end
+
+  test "draft creation does not move sequence counter" do
+    sequence = invoice_sequences(:default_a_active)
+    original_last = sequence.last_number
+
+    post invoices_url,
+         params: {
+           save_draft: true,
+           invoice: {
+             date: Date.today,
+             due_date: Date.today + 30,
+             subtotal: 100,
+             iva: 21,
+             total: 121,
+             client_id: clients(:one).id
+           }
+         }
+
+    assert_redirected_to invoices_url(locale: I18n.locale)
+    assert_equal original_last, sequence.reload.last_number
+    assert_nil Invoice.last.number
   end
 
   test "should show invoice" do
@@ -126,9 +202,78 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to invoices_url(locale: I18n.locale)
   end
 
-  test "should destroy invoice" do
-    assert_difference("Invoice.count", -1) { delete invoice_url(@invoice) }
+  test "should destroy draft invoice" do
+    assert_difference("Invoice.count", -1) do
+      delete invoice_url(@draft)
+    end
 
     assert_redirected_to invoices_url(locale: I18n.locale)
+  end
+
+  test "should not destroy issued invoice" do
+    assert_no_difference("Invoice.count") do
+      delete invoice_url(@invoice)
+    end
+
+    assert_redirected_to invoices_url(locale: I18n.locale)
+    assert_match I18n.t('invoice.destroy_blocked'), flash[:alert]
+  end
+
+  test "should issue a draft invoice" do
+    sequence = invoice_sequences(:default_a_active)
+    original_last = sequence.last_number
+
+    post issue_invoice_url(@draft)
+
+    assert_redirected_to invoices_url(locale: I18n.locale)
+    @draft.reload
+    assert_equal 'pendiente', @draft.status
+    assert_equal original_last + 1, @draft.number
+    assert_equal invoice_series(:default_a), @draft.series
+  end
+
+  test "two sequential issues produce n, n+1" do
+    sequence = invoice_sequences(:default_a_active)
+    original_last = sequence.last_number
+
+    # Create first draft
+    post invoices_url,
+         params: {
+           save_draft: true,
+           invoice: {
+             date: Date.today,
+             due_date: Date.today + 30,
+             subtotal: 100,
+             iva: 21,
+             total: 121,
+             client_id: clients(:one).id
+           }
+         }
+    first_draft = Invoice.last
+
+    # Create second draft
+    post invoices_url,
+         params: {
+           save_draft: true,
+           invoice: {
+             date: Date.today,
+             due_date: Date.today + 30,
+             subtotal: 200,
+             iva: 42,
+             total: 242,
+             client_id: clients(:one).id
+           }
+         }
+    second_draft = Invoice.last
+
+    # Issue first
+    post issue_invoice_url(first_draft)
+    first_draft.reload
+    assert_equal original_last + 1, first_draft.number
+
+    # Issue second
+    post issue_invoice_url(second_draft)
+    second_draft.reload
+    assert_equal original_last + 2, second_draft.number
   end
 end

--- a/test/fixtures/invoices.yml
+++ b/test/fixtures/invoices.yml
@@ -44,3 +44,17 @@ three:
     client: one
     series: default_a
     number: 102
+
+draft_one:
+    date: <%= Faker::Date.between(from: 30.days.ago, to: Date.today) %>
+    due_date: <%= Faker::Date.forward(days: 30) %>
+    notes: Draft invoice
+    status: borrador
+    subtotal: 50.0
+    iva: 10.5
+    irpf: 0.0
+    total: 60.5
+    user: first
+    client: one
+    series:
+    number:

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -91,4 +91,80 @@ class InvoiceTest < ActiveSupport::TestCase
     # The sequence counter should remain unchanged
     assert_equal original_last, sequence.reload.last_number
   end
+
+  test "draft? returns true for borrador status" do
+    invoice = invoices(:draft_one)
+    assert invoice.draft?
+    assert_not invoice.issued?
+  end
+
+  test "issued? returns true for pendiente and pagada" do
+    invoice = invoices(:one)
+    assert invoice.issued?
+    assert_not invoice.draft?
+  end
+
+  test "issue! transitions draft to pendiente with number" do
+    draft = invoices(:draft_one)
+    sequence = invoice_sequences(:default_a_active)
+    original_last = sequence.last_number
+
+    Invoice.transaction do
+      draft.issue!
+    end
+
+    assert_equal 'pendiente', draft.status
+    assert_equal original_last + 1, draft.number
+    assert_equal invoice_series(:default_a), draft.series
+  end
+
+  test "issue! raises error for non-draft invoice" do
+    invoice = invoices(:one)
+    assert_raises(RuntimeError) { invoice.issue! }
+  end
+
+  test "failed issue does not burn a number" do
+    sequence = invoice_sequences(:default_a_active)
+    original_last = sequence.last_number
+
+    draft = invoices(:draft_one)
+    # Make the draft invalid by removing the client
+    draft.client_id = nil
+
+    begin
+      Invoice.transaction do
+        draft.issue!
+      end
+    rescue StandardError
+      # Expected to fail
+    end
+
+    assert_equal original_last, sequence.reload.last_number
+    assert_equal 'borrador', draft.reload.status
+    assert_nil draft.number
+  end
+
+  test "cannot destroy issued invoice" do
+    invoice = invoices(:one)
+    assert_not invoice.destroy
+    assert invoice.persisted?
+    assert_includes invoice.errors[:base], I18n.t('invoice.destroy_blocked')
+  end
+
+  test "can destroy draft invoice" do
+    draft = invoices(:draft_one)
+    assert draft.destroy
+    assert draft.destroyed?
+  end
+
+  test "default status is borrador" do
+    invoice = Invoice.new
+    assert_equal 'borrador', invoice.status
+  end
+
+  test "validates status inclusion" do
+    invoice = Invoice.new(status: 'invalid')
+    assert_not invoice.valid?
+    assert invoice.errors[:status].any?
+  end
 end


### PR DESCRIPTION
- Add borrador status as default for new invoices with NULL number
- Add POST /invoices/:id/issue endpoint for draft → pendiente transition
- Atomic number reservation via SELECT FOR UPDATE in transaction
- Block destroy of issued invoices at model level (before_destroy callback)
- Draft badge (yellow pill) on list/show views
- Issue button replaces PDF download for drafts
- Delete button only shown for drafts
- Two-button form: 'Save as Draft' and 'Save and Issue'
- Borrador filter option in invoice list
- Remove :status from permitted params (prevents lifecycle bypass)
- Full en+es translations for all new strings
- 72 tests, 181 assertions, 0 failures