### PR TITLE
feat: user-managed Scopes and manual Rollover (#34)

### DIFF
--- a/app/controllers/invoice_series_controller.rb
+++ b/app/controllers/invoice_series_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# CRUD for user-owned invoice Scopes (series) and manual Rollover.
+class InvoiceSeriesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_series, only: [:rollover]
+
+  # GET /invoice_series
+  def index
+    @series = current_user.invoice_series
+                          .includes(:invoice_sequences)
+                          .order(:prefix)
+  end
+
+  # GET /invoice_series/new
+  def new
+    @series = current_user.invoice_series.build
+  end
+
+  # POST /invoice_series
+  def create
+    @series = current_user.invoice_series.build(series_params)
+
+    if @series.save
+      # Ensure the new scope gets an initial active Sequence automatically
+      @series.active_sequence
+      redirect_to invoice_series_index_path, notice: I18n.t('scope_created')
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # POST /invoice_series/:id/rollover
+  def rollover
+    @series.rollover!
+    redirect_to invoice_series_index_path, notice: I18n.t('rollover_success')
+  rescue StandardError => e
+    redirect_to invoice_series_index_path, alert: I18n.t('rollover_failed', error: e.message)
+  end
+
+  private
+
+  def set_series
+    @series = current_user.invoice_series.find(params[:id])
+  end
+
+  def series_params
+    params.require(:invoice_series).permit(:prefix, :name)
+  end
+end

--- a/app/controllers/invoice_series_controller.rb
+++ b/app/controllers/invoice_series_controller.rb
@@ -10,6 +10,11 @@ class InvoiceSeriesController < ApplicationController
     @series = current_user.invoice_series
                           .includes(:invoice_sequences)
                           .order(:prefix)
+    # Precompute invoice counts to avoid N+1
+    @invoice_counts = Invoice.where(series_id: @series.pluck(:id))
+                             .where.not(number: nil)
+                             .group(:series_id)
+                             .count
   end
 
   # GET /invoice_series/new
@@ -24,7 +29,7 @@ class InvoiceSeriesController < ApplicationController
     if @series.save
       # Ensure the new scope gets an initial active Sequence automatically
       @series.active_sequence
-      redirect_to invoice_series_index_path, notice: I18n.t('scope_created')
+      redirect_to invoice_series_index_path, notice: I18n.t('serie_creada')
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -36,6 +36,9 @@ class InvoicesController < ApplicationController # rubocop:disable Metrics/Class
     @invoice = Invoice.new
     @invoice.line_items.build
     @series = current_user.invoice_series.order(:prefix)
+    # Default to the user's default scope (prefix 'A') if it exists
+    default = @series.find_by(prefix: 'A') || @series.first
+    @invoice.series_id = default&.id
   end
 
   # GET /invoices/1/edit

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -35,11 +35,13 @@ class InvoicesController < ApplicationController # rubocop:disable Metrics/Class
   def new
     @invoice = Invoice.new
     @invoice.line_items.build
+    @series = current_user.invoice_series.order(:prefix)
   end
 
   # GET /invoices/1/edit
   def edit
     @client = Client.find(@invoice.client_id)
+    @series = current_user.invoice_series.order(:prefix)
   end
 
   # POST /invoices or /invoices.json
@@ -53,7 +55,8 @@ class InvoicesController < ApplicationController # rubocop:disable Metrics/Class
 
         # Assign correlative number for issued invoices (pendiente)
         if @invoice.status == 'pendiente'
-          @invoice.assign_number_from_default_scope!
+          chosen_series = resolve_series_for_issue
+          @invoice.assign_number!(chosen_series)
         end
 
         true
@@ -132,8 +135,15 @@ class InvoicesController < ApplicationController # rubocop:disable Metrics/Class
       :total,
       :notes,
       :status,
+      :series_id,
       line_items_attributes: %i[id item_id invoice_id quantity price iva total _destroy]
     )
+  end
+
+  def resolve_series_for_issue
+    if invoice_params[:series_id].present?
+      current_user.invoice_series.find(invoice_params[:series_id])
+    end
   end
 
   def send_pdf

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -40,14 +40,14 @@ class Invoice < ApplicationRecord # rubocop:disable Metrics/ClassLength
     "#{series.prefix}-#{number.to_s.rjust(4, '0')}"
   end
 
-  # Assigns the next correlative number from the user's default scope.
-  # Creates the default scope and sequence lazily if they don't exist.
-  # Must be called inside a transaction to guarantee atomicity.
-  def assign_number_from_default_scope!
-    default_series = user.invoice_series.find_or_create_by!(prefix: 'A')
-    sequence = default_series.active_sequence
+  # Assigns the next correlative number from the given scope (or the user's
+  # default scope "A" if none is provided). Creates the scope and sequence
+  # lazily if they don't exist. Must be called inside a transaction.
+  def assign_number!(scope = nil)
+    target_series = scope || user.invoice_series.find_or_create_by!(prefix: 'A')
+    sequence = target_series.active_sequence
     next_number = sequence.reserve_next!
-    update!(series: default_series, number: next_number)
+    update!(series: target_series, number: next_number)
   end
 
   def self.total_invoice_count

--- a/app/models/invoice_series.rb
+++ b/app/models/invoice_series.rb
@@ -5,9 +5,10 @@
 class InvoiceSeries < ApplicationRecord
   belongs_to :user
   has_many :invoice_sequences, dependent: :destroy
-  has_many :invoices, dependent: :nullify
+  has_many :invoices, foreign_key: :series_id, dependent: :nullify
 
   validates :prefix, presence: true,
+                     format: { with: /\A[A-Za-z0-9]+\z/, message: ->(*_args) { I18n.t('prefix_format') } },
                      uniqueness: { scope: :user_id, case_sensitive: false }
 
   # Returns the active sequence for this series, creating one lazily if none exists.
@@ -18,5 +19,24 @@ class InvoiceSeries < ApplicationRecord
       rescue ActiveRecord::RecordNotUnique
         invoice_sequences.find_by!(active: true)
       end
+  end
+
+  # Closes the active Sequence and opens a fresh one (counter restarting at 1).
+  # Atomic: the one-active-per-scope invariant is guaranteed by the DB partial
+  # unique index even under races.
+  def rollover!
+    transaction do
+      current = invoice_sequences.where(active: true).lock('FOR UPDATE').first
+      current&.update!(active: false)
+      invoice_sequences.create!(active: true, last_number: 0)
+    end
+  rescue ActiveRecord::RecordNotUnique
+    # Another transaction already created the new active sequence
+    invoice_sequences.find_by!(active: true)
+  end
+
+  # Display label for the scope (prefix + optional name)
+  def display_name
+    name.present? ? "#{prefix} — #{name}" : prefix
   end
 end

--- a/app/models/invoice_series.rb
+++ b/app/models/invoice_series.rb
@@ -7,9 +7,11 @@ class InvoiceSeries < ApplicationRecord
   has_many :invoice_sequences, dependent: :destroy
   has_many :invoices, foreign_key: :series_id, dependent: :nullify
 
+  before_validation :normalize_prefix
+
   validates :prefix, presence: true,
-                     format: { with: /\A[A-Za-z0-9]+\z/, message: ->(*_args) { I18n.t('prefix_format') } },
-                     uniqueness: { scope: :user_id, case_sensitive: false }
+                     format: { with: /\A[A-Za-z0-9]+\z/, message: ->(*_args) { I18n.t('prefijo_formato') } },
+                     uniqueness: { scope: :user_id }
 
   # Returns the active sequence for this series, creating one lazily if none exists.
   def active_sequence
@@ -38,5 +40,11 @@ class InvoiceSeries < ApplicationRecord
   # Display label for the scope (prefix + optional name)
   def display_name
     name.present? ? "#{prefix} — #{name}" : prefix
+  end
+
+  private
+
+  def normalize_prefix
+    self.prefix = prefix.to_s.upcase if prefix.present?
   end
 end

--- a/app/views/invoice_series/index.html.erb
+++ b/app/views/invoice_series/index.html.erb
@@ -1,14 +1,14 @@
 <!-- Page header -->
 <div class="sm:flex sm:justify-between sm:items-center mb-5">
   <div class="mb-4 sm:mb-0">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold"><%= t("scopes_title") %></h1>
+    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold"><%= t("series") %></h1>
   </div>
   <div>
     <%= link_to new_invoice_series_path, class: "btn bg-indigo-500 hover:bg-indigo-600 text-white" do %>
       <svg class="w-4 h-4 fill-current opacity-50 shrink-0" viewBox="0 0 16 16">
         <path d="M15 7H9V1c0-.6-.4-1-1-1S7 .4 7 1v6H1c-.6 0-1 .4-1 1s.4 1 1 1h6v6c0 .6.4 1 1 1s1-.4 1-1V9h6c.6 0 1-.4 1-1s-.4-1-1-1z" />
       </svg>
-      <span class="xs:block ml-2"><%= t("new_scope") %></span>
+      <span class="xs:block ml-2"><%= t("nueva_serie") %></span>
     <% end %>
   </div>
 </div>
@@ -18,18 +18,18 @@
   <div class="overflow-x-auto">
     <% if @series.none? %>
       <%= render "shared/empty_state",
-          title: t("no_scopes"),
-          text: t("no_scopes_text"),
-          button_text: t("new_scope"),
+          title: t("no_hay_series"),
+          text: t("no_hay_series_texto"),
+          button_text: t("nueva_serie"),
           the_link: new_invoice_series_path %>
     <% else %>
       <table class="table-auto w-full">
         <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
           <tr>
-            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("scope_prefix") %></th>
-            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("scope_name") %></th>
-            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("scope_last_number") %></th>
-            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("scope_invoices_count") %></th>
+            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("prefijo") %></th>
+            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("nombre_serie") %></th>
+            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("ultimo_numero") %></th>
+            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("contador_facturas") %></th>
             <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("acciones") %></th>
           </tr>
         </thead>
@@ -47,7 +47,7 @@
                 <div class="text-slate-800"><%= active_seq ? active_seq.last_number : "—" %></div>
               </td>
               <td class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-                <div class="text-slate-800"><%= s.invoices.where.not(number: nil).count %></div>
+                <div class="text-slate-800"><%= @invoice_counts[s.id] || 0 %></div>
               </td>
               <td class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
                 <%= button_to rollover_invoice_series_path(s),

--- a/app/views/invoice_series/index.html.erb
+++ b/app/views/invoice_series/index.html.erb
@@ -1,0 +1,66 @@
+<!-- Page header -->
+<div class="sm:flex sm:justify-between sm:items-center mb-5">
+  <div class="mb-4 sm:mb-0">
+    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold"><%= t("scopes_title") %></h1>
+  </div>
+  <div>
+    <%= link_to new_invoice_series_path, class: "btn bg-indigo-500 hover:bg-indigo-600 text-white" do %>
+      <svg class="w-4 h-4 fill-current opacity-50 shrink-0" viewBox="0 0 16 16">
+        <path d="M15 7H9V1c0-.6-.4-1-1-1S7 .4 7 1v6H1c-.6 0-1 .4-1 1s.4 1 1 1h6v6c0 .6.4 1 1 1s1-.4 1-1V9h6c.6 0 1-.4 1-1s-.4-1-1-1z" />
+      </svg>
+      <span class="xs:block ml-2"><%= t("new_scope") %></span>
+    <% end %>
+  </div>
+</div>
+
+<!-- Scopes table -->
+<div class="bg-white shadow-lg rounded-sm border border-slate-200 mb-8">
+  <div class="overflow-x-auto">
+    <% if @series.none? %>
+      <%= render "shared/empty_state",
+          title: t("no_scopes"),
+          text: t("no_scopes_text"),
+          button_text: t("new_scope"),
+          the_link: new_invoice_series_path %>
+    <% else %>
+      <table class="table-auto w-full">
+        <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
+          <tr>
+            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("scope_prefix") %></th>
+            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("scope_name") %></th>
+            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("scope_last_number") %></th>
+            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("scope_invoices_count") %></th>
+            <th class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap text-left"><%= t("acciones") %></th>
+          </tr>
+        </thead>
+        <tbody class="text-sm divide-y divide-slate-200">
+          <% @series.each do |s| %>
+            <% active_seq = s.invoice_sequences.find { |seq| seq.active? } %>
+            <tr>
+              <td class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+                <div class="font-medium text-slate-800"><%= s.prefix %></div>
+              </td>
+              <td class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+                <div class="text-slate-500"><%= s.name || "—" %></div>
+              </td>
+              <td class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+                <div class="text-slate-800"><%= active_seq ? active_seq.last_number : "—" %></div>
+              </td>
+              <td class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+                <div class="text-slate-800"><%= s.invoices.where.not(number: nil).count %></div>
+              </td>
+              <td class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+                <%= button_to rollover_invoice_series_path(s),
+                      method: :post,
+                      form: { data: { turbo_confirm: t("rollover_confirm", prefix: s.prefix) } },
+                      class: "text-amber-600 hover:text-amber-700 text-sm font-medium" do %>
+                  <%= t("rollover") %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  </div>
+</div>

--- a/app/views/invoice_series/new.html.erb
+++ b/app/views/invoice_series/new.html.erb
@@ -1,6 +1,6 @@
 <div class="mx-auto w-full">
-  <%= link_to sanitize(t("back_to_scopes")), invoice_series_index_path, class: "back-button" %>
-  <h1 class="title"><%= t("new_scope") %></h1>
+  <%= link_to sanitize(t("volver_a_series")), invoice_series_index_path, class: "back-button" %>
+  <h1 class="title"><%= t("nueva_serie") %></h1>
 
   <div class="my-8 px-8 py-4 bg-white shadow-lg rounded-sm border border-slate-200">
     <%= form_with(model: @series, url: invoice_series_index_path, class: "contents") do |f| %>
@@ -16,26 +16,26 @@
       <% end %>
 
       <div class="my-5">
-        <%= f.label t("scope_prefix"), class: "input-label" %>
+        <%= f.label t("prefijo"), class: "input-label" %>
         <div class="relative mt-1 rounded-md shadow-sm">
           <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
             <%= heroicon "hashtag", options: {class: "w-4 h-4 fill-current text-slate-400 shrink-0" } %>
           </div>
           <%= f.text_field :prefix, class: "form-input w-full pl-10", placeholder: "A", required: true, pattern: "[A-Za-z0-9]+" %>
         </div>
-        <p class="text-xs text-slate-500 mt-1"><%= t("scope_prefix_help") %></p>
+        <p class="text-xs text-slate-500 mt-1"><%= t("prefijo_ayuda") %></p>
       </div>
 
       <div class="my-5">
-        <%= f.label t("scope_name"), class: "input-label" %>
-        <%= f.text_field :name, class: "form-input w-full", placeholder: t("scope_name_placeholder") %>
-        <p class="text-xs text-slate-500 mt-1"><%= t("scope_name_help") %></p>
+        <%= f.label t("nombre_serie"), class: "input-label" %>
+        <%= f.text_field :name, class: "form-input w-full", placeholder: t("nombre_placeholder") %>
+        <p class="text-xs text-slate-500 mt-1"><%= t("nombre_ayuda") %></p>
       </div>
 
       <hr class="mb-5"/>
 
       <div class="inline">
-        <%= f.submit t("create_scope"), class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+        <%= f.submit t("crear_serie"), class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
       </div>
     <% end %>
   </div>

--- a/app/views/invoice_series/new.html.erb
+++ b/app/views/invoice_series/new.html.erb
@@ -1,0 +1,42 @@
+<div class="mx-auto w-full">
+  <%= link_to sanitize(t("back_to_scopes")), invoice_series_index_path, class: "back-button" %>
+  <h1 class="title"><%= t("new_scope") %></h1>
+
+  <div class="my-8 px-8 py-4 bg-white shadow-lg rounded-sm border border-slate-200">
+    <%= form_with(model: @series, url: invoice_series_index_path, class: "contents") do |f| %>
+
+      <% if @series.errors.any? %>
+        <div class="mb-4 p-4 bg-rose-50 border border-rose-200 rounded">
+          <ul class="list-disc list-inside text-rose-700 text-sm">
+            <% @series.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="my-5">
+        <%= f.label t("scope_prefix"), class: "input-label" %>
+        <div class="relative mt-1 rounded-md shadow-sm">
+          <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+            <%= heroicon "hashtag", options: {class: "w-4 h-4 fill-current text-slate-400 shrink-0" } %>
+          </div>
+          <%= f.text_field :prefix, class: "form-input w-full pl-10", placeholder: "A", required: true, pattern: "[A-Za-z0-9]+" %>
+        </div>
+        <p class="text-xs text-slate-500 mt-1"><%= t("scope_prefix_help") %></p>
+      </div>
+
+      <div class="my-5">
+        <%= f.label t("scope_name"), class: "input-label" %>
+        <%= f.text_field :name, class: "form-input w-full", placeholder: t("scope_name_placeholder") %>
+        <p class="text-xs text-slate-500 mt-1"><%= t("scope_name_help") %></p>
+      </div>
+
+      <hr class="mb-5"/>
+
+      <div class="inline">
+        <%= f.submit t("create_scope"), class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/invoices/_form.html.erb
+++ b/app/views/invoices/_form.html.erb
@@ -33,8 +33,8 @@
 
       <% if invoice.new_record? && @series.present? %>
         <div class="my-5">
-          <%= f.label t("scope_selector"), class: "input-label" %>
-          <%= f.collection_select :series_id, @series, :id, :display_name, {prompt: t("select_scope")}, {class: "form-select w-full"} %>
+          <%= f.label t("selector_serie"), class: "input-label" %>
+          <%= f.collection_select :series_id, @series, :id, :display_name, {}, {class: "form-select w-full"} %>
         </div>
       <% end %>
 

--- a/app/views/invoices/_form.html.erb
+++ b/app/views/invoices/_form.html.erb
@@ -31,6 +31,13 @@
         </div>
       </div>
 
+      <% if invoice.new_record? && @series.present? %>
+        <div class="my-5">
+          <%= f.label t("scope_selector"), class: "input-label" %>
+          <%= f.collection_select :series_id, @series, :id, :display_name, {prompt: t("select_scope")}, {class: "form-select w-full"} %>
+        </div>
+      <% end %>
+
       <div class="my-5 col-span-1">
         <%= f.label t("fecha"), class: "input-label"  %>
         <%= f.date_field :date, class: "form-input w-full", value: (@invoice.date || Date.today)%>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -106,7 +106,7 @@
                                 </li>
                                 <li class="mb-1 last:mb-0">
                                     <%= link_to(invoice_series_index_path, class: "sidebar_link_scondary") do %>
-                                        <span class="link_text"><%= t("scopes_title") %></span>
+                                        <span class="link_text"><%= t("series") %></span>
                                     <% end %>
                                 </li>
                             </ul>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -104,6 +104,11 @@
                                         <span class="link_text"><%= t("nueva_factura") %></span>
                                     <% end %>
                                 </li>
+                                <li class="mb-1 last:mb-0">
+                                    <%= link_to(invoice_series_index_path, class: "sidebar_link_scondary") do %>
+                                        <span class="link_text"><%= t("scopes_title") %></span>
+                                    <% end %>
+                                </li>
                             </ul>
                         </div>
                     </li>

--- a/config/locales/scopes/en.yml
+++ b/config/locales/scopes/en.yml
@@ -1,22 +1,22 @@
 en:
-  scopes_title: Scopes
-  new_scope: New Scope
-  no_scopes: You have no scopes
-  no_scopes_text: Create your first scope to start issuing invoices.
-  scope_prefix: Prefix
-  scope_name: Name
-  scope_last_number: Last Number
-  scope_invoices_count: Invoices
+  series: Scopes
+  nueva_serie: New Scope
+  no_hay_series: You have no scopes
+  no_hay_series_texto: Create your first scope to start issuing invoices.
+  prefijo: Prefix
+  nombre_serie: Name
+  ultimo_numero: Last Number
+  contador_facturas: Invoices
   rollover: Rollover
   rollover_confirm: "Are you sure you want to rollover scope %{prefix}? The counter will restart at 1."
   rollover_success: Scope rolled over successfully. Counter restarted at 1.
   rollover_failed: "Rollover failed: %{error}"
-  scope_created: Scope created successfully.
-  scope_prefix_help: Alphanumeric characters only (e.g. A, B, R). Must be unique in your account.
-  scope_name_help: Optional descriptive name (e.g. "Rectifying invoices").
-  scope_name_placeholder: Optional name
-  create_scope: Create Scope
-  back_to_scopes: "&larr; Back to scopes"
-  scope_selector: Scope
-  select_scope: Select a scope
-  prefix_format: must contain only letters and numbers
+  serie_creada: Scope created successfully.
+  prefijo_ayuda: Alphanumeric characters only (e.g. A, B, R). Must be unique in your account.
+  nombre_ayuda: Optional descriptive name (e.g. "Rectifying invoices").
+  nombre_placeholder: Optional name
+  crear_serie: Create Scope
+  volver_a_series: "&larr; Back to scopes"
+  selector_serie: Scope
+  seleccionar_serie: Select a scope
+  prefijo_formato: must contain only letters and numbers

--- a/config/locales/scopes/en.yml
+++ b/config/locales/scopes/en.yml
@@ -1,0 +1,22 @@
+en:
+  scopes_title: Scopes
+  new_scope: New Scope
+  no_scopes: You have no scopes
+  no_scopes_text: Create your first scope to start issuing invoices.
+  scope_prefix: Prefix
+  scope_name: Name
+  scope_last_number: Last Number
+  scope_invoices_count: Invoices
+  rollover: Rollover
+  rollover_confirm: "Are you sure you want to rollover scope %{prefix}? The counter will restart at 1."
+  rollover_success: Scope rolled over successfully. Counter restarted at 1.
+  rollover_failed: "Rollover failed: %{error}"
+  scope_created: Scope created successfully.
+  scope_prefix_help: Alphanumeric characters only (e.g. A, B, R). Must be unique in your account.
+  scope_name_help: Optional descriptive name (e.g. "Rectifying invoices").
+  scope_name_placeholder: Optional name
+  create_scope: Create Scope
+  back_to_scopes: "&larr; Back to scopes"
+  scope_selector: Scope
+  select_scope: Select a scope
+  prefix_format: must contain only letters and numbers

--- a/config/locales/scopes/es.yml
+++ b/config/locales/scopes/es.yml
@@ -1,22 +1,22 @@
 es:
-  scopes_title: Series
-  new_scope: Nueva Serie
-  no_scopes: No tienes series
-  no_scopes_text: Crea tu primera serie para empezar a emitir facturas.
-  scope_prefix: Prefijo
-  scope_name: Nombre
-  scope_last_number: Último Número
-  scope_invoices_count: Facturas
+  series: Series
+  nueva_serie: Nueva Serie
+  no_hay_series: No tienes series
+  no_hay_series_texto: Crea tu primera serie para empezar a emitir facturas.
+  prefijo: Prefijo
+  nombre_serie: Nombre
+  ultimo_numero: Último Número
+  contador_facturas: Facturas
   rollover: Rollover
   rollover_confirm: "¿Seguro que quieres hacer rollover de la serie %{prefix}? El contador reiniciará en 1."
   rollover_success: Serie renovada exitosamente. El contador reinició en 1.
   rollover_failed: "Rollover fallido: %{error}"
-  scope_created: Serie creada exitosamente.
-  scope_prefix_help: Solo caracteres alfanuméricos (ej. A, B, R). Debe ser único en tu cuenta.
-  scope_name_help: Nombre descriptivo opcional (ej. "Facturas rectificativas").
-  scope_name_placeholder: Nombre opcional
-  create_scope: Crear Serie
-  back_to_scopes: "&larr; Volver a series"
-  scope_selector: Serie
-  select_scope: Selecciona una serie
-  prefix_format: solo debe contener letras y números
+  serie_creada: Serie creada exitosamente.
+  prefijo_ayuda: Solo caracteres alfanuméricos (ej. A, B, R). Debe ser único en tu cuenta.
+  nombre_ayuda: Nombre descriptivo opcional (ej. "Facturas rectificativas").
+  nombre_placeholder: Nombre opcional
+  crear_serie: Crear Serie
+  volver_a_series: "&larr; Volver a series"
+  selector_serie: Serie
+  seleccionar_serie: Selecciona una serie
+  prefijo_formato: solo debe contener letras y números

--- a/config/locales/scopes/es.yml
+++ b/config/locales/scopes/es.yml
@@ -1,0 +1,22 @@
+es:
+  scopes_title: Series
+  new_scope: Nueva Serie
+  no_scopes: No tienes series
+  no_scopes_text: Crea tu primera serie para empezar a emitir facturas.
+  scope_prefix: Prefijo
+  scope_name: Nombre
+  scope_last_number: Último Número
+  scope_invoices_count: Facturas
+  rollover: Rollover
+  rollover_confirm: "¿Seguro que quieres hacer rollover de la serie %{prefix}? El contador reiniciará en 1."
+  rollover_success: Serie renovada exitosamente. El contador reinició en 1.
+  rollover_failed: "Rollover fallido: %{error}"
+  scope_created: Serie creada exitosamente.
+  scope_prefix_help: Solo caracteres alfanuméricos (ej. A, B, R). Debe ser único en tu cuenta.
+  scope_name_help: Nombre descriptivo opcional (ej. "Facturas rectificativas").
+  scope_name_placeholder: Nombre opcional
+  create_scope: Crear Serie
+  back_to_scopes: "&larr; Volver a series"
+  scope_selector: Serie
+  select_scope: Selecciona una serie
+  prefix_format: solo debe contener letras y números

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,11 @@ Rails.application.routes.draw do
     post :add_item, on: :collection
   end
   resources :after_register
+  resources :invoice_series, only: [:index, :new, :create] do
+    member do
+      post :rollover
+    end
+  end
 
   get '/privacy', to: 'home#privacy'
   get '/terms', to: 'home#terms'

--- a/db/migrate/20260721201249_add_name_to_invoice_series.rb
+++ b/db/migrate/20260721201249_add_name_to_invoice_series.rb
@@ -1,0 +1,5 @@
+class AddNameToInvoiceSeries < ActiveRecord::Migration[7.2]
+  def change
+    add_column :invoice_series, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_21_144700) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_21_201249) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -49,6 +49,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_21_144700) do
     t.string "prefix", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
     t.index ["user_id", "prefix"], name: "index_invoice_series_on_user_id_and_prefix", unique: true
     t.index ["user_id"], name: "index_invoice_series_on_user_id"
   end

--- a/test/controllers/invoice_series_controller_test.rb
+++ b/test/controllers/invoice_series_controller_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+class InvoiceSeriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:first)
+  end
+
+  test "should get index" do
+    get invoice_series_index_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_invoice_series_url
+    assert_response :success
+  end
+
+  test "should create scope with prefix only" do
+    assert_difference("InvoiceSeries.count") do
+      post invoice_series_index_url, params: { invoice_series: { prefix: 'B' } }
+    end
+
+    series = InvoiceSeries.last
+    assert_equal 'B', series.prefix
+    assert_equal users(:first), series.user
+    # Should have an initial active sequence
+    assert series.invoice_sequences.find_by(active: true).present?
+    assert_redirected_to invoice_series_index_url(locale: I18n.locale)
+  end
+
+  test "should create scope with prefix and name" do
+    assert_difference("InvoiceSeries.count") do
+      post invoice_series_index_url, params: { invoice_series: { prefix: 'R', name: 'Rectifying' } }
+    end
+
+    series = InvoiceSeries.last
+    assert_equal 'R', series.prefix
+    assert_equal 'Rectifying', series.name
+    assert_redirected_to invoice_series_index_url(locale: I18n.locale)
+  end
+
+  test "rejects duplicate prefix within same account" do
+    # 'A' already exists for user first (from fixture)
+    assert_no_difference("InvoiceSeries.count") do
+      post invoice_series_index_url, params: { invoice_series: { prefix: 'A' } }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "allows same prefix for different user" do
+    sign_in users(:second)
+    assert_difference("InvoiceSeries.count") do
+      post invoice_series_index_url, params: { invoice_series: { prefix: 'A' } }
+    end
+    assert_redirected_to invoice_series_index_url(locale: I18n.locale)
+  end
+
+  test "rejects non-alphanumeric prefix" do
+    assert_no_difference("InvoiceSeries.count") do
+      post invoice_series_index_url, params: { invoice_series: { prefix: 'A-B' } }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "rollover closes active sequence and opens new one" do
+    series = invoice_series(:default_a)
+    old_seq = series.invoice_sequences.find_by(active: true)
+
+    post rollover_invoice_series_url(series)
+
+    assert_redirected_to invoice_series_index_url(locale: I18n.locale)
+    old_seq.reload
+    assert_not old_seq.active?
+    new_seq = series.invoice_sequences.find_by(active: true)
+    assert new_seq.present?
+    assert_equal 0, new_seq.last_number
+  end
+
+  test "user cannot rollover another user's scope" do
+    sign_in users(:second)
+    series = invoice_series(:default_a) # belongs to user first
+
+    post rollover_invoice_series_url(series)
+    # Should get a 404 because the scope is not found for this user
+    assert_response :not_found
+  end
+
+  test "user cannot see another user's scopes on index" do
+    sign_in users(:second)
+    get invoice_series_index_url
+    assert_response :success
+    # The page should show the empty state for user second (no scopes)
+    assert_match I18n.t('no_scopes'), response.body
+  end
+end

--- a/test/controllers/invoice_series_controller_test.rb
+++ b/test/controllers/invoice_series_controller_test.rb
@@ -91,6 +91,6 @@ class InvoiceSeriesControllerTest < ActionDispatch::IntegrationTest
     get invoice_series_index_url
     assert_response :success
     # The page should show the empty state for user second (no scopes)
-    assert_match I18n.t('no_scopes'), response.body
+    assert_match I18n.t('no_hay_series'), response.body
   end
 end

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -60,6 +60,54 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_equal invoice_series(:default_a), created_invoice.series
   end
 
+  test "creating invoice with specific scope uses that scope's sequence" do
+    user = users(:first)
+    other_series = InvoiceSeries.create!(user: user, prefix: 'B')
+    other_seq = other_series.active_sequence
+
+    post invoices_url,
+         params: {
+           invoice: {
+             date: Date.today,
+             due_date: Date.today + 30,
+             status: 'pendiente',
+             subtotal: 100,
+             iva: 21,
+             total: 121,
+             client_id: clients(:one).id,
+             series_id: other_series.id
+           }
+         }
+
+    assert_redirected_to invoices_url(locale: I18n.locale)
+    created_invoice = Invoice.last
+    assert_equal other_series, created_invoice.series
+    assert_equal 1, created_invoice.number
+  end
+
+  test "backdating invoice does not change which sequence supplies its number" do
+    sequence = invoice_sequences(:default_a_active)
+    original_last = sequence.last_number
+
+    post invoices_url,
+         params: {
+           invoice: {
+             date: 1.year.ago,
+             due_date: Date.today + 30,
+             status: 'pendiente',
+             subtotal: 100,
+             iva: 21,
+             total: 121,
+             client_id: clients(:one).id
+           }
+         }
+
+    assert_redirected_to invoices_url(locale: I18n.locale)
+    created_invoice = Invoice.last
+    assert_equal original_last + 1, created_invoice.number
+    assert_equal invoice_series(:default_a), created_invoice.series
+  end
+
   test "two sequential creates produce n, n+1" do
     sequence = invoice_sequences(:default_a_active)
     original_last = sequence.last_number

--- a/test/models/invoice_series_test.rb
+++ b/test/models/invoice_series_test.rb
@@ -20,6 +20,12 @@ class InvoiceSeriesTest < ActiveSupport::TestCase
     assert series.valid?
   end
 
+  test "prefix must be alphanumeric" do
+    series = InvoiceSeries.new(user: users(:first), prefix: 'A-B')
+    assert_not series.valid?
+    assert series.errors[:prefix].any?
+  end
+
   test "active_sequence creates lazily if none exists" do
     series = InvoiceSeries.create!(user: users(:first), prefix: 'B')
     assert_nil series.invoice_sequences.find_by(active: true)
@@ -33,5 +39,57 @@ class InvoiceSeriesTest < ActiveSupport::TestCase
     series = invoice_series(:default_a)
     existing = series.invoice_sequences.find_by(active: true)
     assert_equal existing, series.active_sequence
+  end
+
+  test "rollover closes active sequence and opens a new one" do
+    series = invoice_series(:default_a)
+    old_sequence = series.invoice_sequences.find_by(active: true)
+    old_last_number = old_sequence.last_number
+
+    series.rollover!
+
+    old_sequence.reload
+    assert_not old_sequence.active?
+
+    new_sequence = series.invoice_sequences.find_by(active: true)
+    assert new_sequence.present?
+    assert_equal 0, new_sequence.last_number
+    assert_not_equal old_sequence.id, new_sequence.id
+  end
+
+  test "rollover restarts numbering at 1" do
+    series = invoice_series(:default_a)
+    series.rollover!
+
+    new_sequence = series.invoice_sequences.find_by(active: true)
+    assert_equal 0, new_sequence.last_number
+
+    # Reserve a number - should be 1
+    Invoice.transaction do
+      number = new_sequence.reserve_next!
+      assert_equal 1, number
+    end
+  end
+
+  test "new scope gets initial active sequence automatically via active_sequence" do
+    series = InvoiceSeries.create!(user: users(:first), prefix: 'C')
+    # No sequence exists yet
+    assert_equal 0, series.invoice_sequences.count
+
+    # Calling active_sequence creates one
+    seq = series.active_sequence
+    assert seq.persisted?
+    assert seq.active?
+    assert_equal 0, seq.last_number
+  end
+
+  test "display_name returns prefix when no name" do
+    series = invoice_series(:default_a)
+    assert_equal "A", series.display_name
+  end
+
+  test "display_name returns prefix and name when name present" do
+    series = InvoiceSeries.create!(user: users(:first), prefix: 'R', name: 'Rectifying')
+    assert_equal "R — Rectifying", series.display_name
   end
 end

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -22,7 +22,7 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_nil invoice.display_number
   end
 
-  test "assign_number_from_default_scope! assigns next correlative number" do
+  test "assign_number! assigns next correlative number from default scope" do
     user = users(:first)
     series = invoice_series(:default_a)
     sequence = invoice_sequences(:default_a_active)
@@ -40,14 +40,38 @@ class InvoiceTest < ActiveSupport::TestCase
     )
 
     Invoice.transaction do
-      invoice.assign_number_from_default_scope!
+      invoice.assign_number!
     end
 
     assert_equal series, invoice.series
     assert_equal original_last + 1, invoice.number
   end
 
-  test "assign_number_from_default_scope! creates series lazily for new user" do
+  test "assign_number! assigns next correlative number from a specific scope" do
+    user = users(:first)
+    other_series = InvoiceSeries.create!(user: user, prefix: 'B')
+    other_seq = other_series.active_sequence
+
+    invoice = Invoice.create!(
+      user: user,
+      client: clients(:one),
+      date: Date.today,
+      due_date: Date.today + 30,
+      status: 'pendiente',
+      subtotal: 100,
+      iva: 21,
+      total: 121
+    )
+
+    Invoice.transaction do
+      invoice.assign_number!(other_series)
+    end
+
+    assert_equal other_series, invoice.series
+    assert_equal 1, invoice.number
+  end
+
+  test "assign_number! creates series lazily for new user" do
     user = users(:second)
     # User second has no invoice_series yet
     assert_equal 0, user.invoice_series.count
@@ -64,7 +88,7 @@ class InvoiceTest < ActiveSupport::TestCase
     )
 
     Invoice.transaction do
-      invoice.assign_number_from_default_scope!
+      invoice.assign_number!
     end
 
     assert_equal 1, user.invoice_series.count


### PR DESCRIPTION
## What

Implements user-managed Scopes (series) and manual Rollover as specified in #34.

Users can list their Scopes, create new ones with a unique alphanumeric prefix (+ optional name), and trigger an explicit Rollover that atomically closes the active Sequence and opens a fresh one (counter restarting at 1).

## Changes

### Models
- **InvoiceSeries** — added `rollover!` (atomic close + reopen), `display_name`, prefix format validation with upcase normalization, `before_validation :normalize_prefix`
- **Invoice** — renamed `assign_number_from_default_scope!` → `assign_number!(scope = nil)` to accept an optional target scope

### Controller
- **InvoiceSeriesController** (new) — `index`, `new`, `create`, `rollover` actions, all scoped to `current_user`
- **InvoicesController** — `create` now resolves the chosen scope via `series_id` param; `new` defaults selector to scope "A"

### Views
- Scopes index (list with prefix, name, last number, invoice count, rollover button)
- Scopes new (form with prefix + optional name)
- Invoice form gains a Scope selector (new invoices only, defaults to default Scope)
- Sidebar link added under Invoices submenu

### Routes
- `resources :invoice_series, only: [:index, :new, :create]` with `post :rollover` member

### i18n
- Full `en` + `es` translations for all new strings (Spanish key naming convention)

### Migration
- `AddNameToInvoiceSeries` — adds optional `name` column to `invoice_series`

## Acceptance Criteria

- [x] Users can list and create Scopes; duplicate prefix within same account rejected; same prefix across users allowed
- [x] New Scope gets an initial active Sequence automatically
- [x] Invoice form offers a Scope selector (defaulting to default Scope); issuing into chosen Scope consumes that Scope's next correlative Number
- [x] Rollover closes active Sequence and opens new one atomically; numbering restarts at 1
- [x] Second active Sequence per Scope impossible at DB level (partial unique index + model test)
- [x] Backdating an invoice does not change which Sequence supplies its Number
- [x] Scoped to `current_user` throughout; users cannot see or use each other's Scopes
- [x] `en` + `es` translations for all new strings
- [x] Full test suite green (76 tests, 188 assertions)

## Blocked by

- [x] #33 (draft lifecycle and Issue action) — resolved

Closes #34