### PR TITLE
feat: exclude drafts from dashboard counts and drop legacy invoice_number column (#35)

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -180,6 +180,7 @@ class InvoicesController < ApplicationController # rubocop:disable Metrics/Class
       :irpf,
       :total,
       :notes,
+      :series_id,
       line_items_attributes: %i[id item_id invoice_id quantity price iva total _destroy]
     )
   end

--- a/app/models/charts/invoices_chart.rb
+++ b/app/models/charts/invoices_chart.rb
@@ -13,6 +13,7 @@ class Charts::InvoicesChart
   def query_data
     Invoice
       .for_account(@user_id)
+      .issued
       .where('invoices.date > ?', 30.days.ago)
       .group('date(invoices.date)')
       .count

--- a/app/models/charts/paid_vs_unpaid_chart.rb
+++ b/app/models/charts/paid_vs_unpaid_chart.rb
@@ -12,6 +12,7 @@ class Charts::PaidVsUnpaidChart
   def query_data
     Invoice
       .for_account(@user_id)
+      .issued
       .group('status')
       .count
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -45,7 +45,7 @@ class Invoice < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def issue!
     raise 'Invoice is not a draft' unless draft?
 
-    assign_number_from_default_scope!
+    assign_number!
     update!(status: 'pendiente')
   end
 
@@ -80,8 +80,10 @@ class Invoice < ApplicationRecord # rubocop:disable Metrics/ClassLength
     update!(series: target_series, number: next_number)
   end
 
+  scope :issued, -> { where.not(status: 'borrador') }
+
   def self.total_invoice_count
-    count
+    issued.count
   end
 
   def self.total_draft_count
@@ -97,11 +99,11 @@ class Invoice < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def self.total_due_count
-    due.count
+    issued.due.count
   end
 
   def self.total_about_to_be_due_count
-    about_to_be_due.count
+    issued.about_to_be_due.count
   end
 
   def sum_subtotal
@@ -151,7 +153,7 @@ class Invoice < ApplicationRecord # rubocop:disable Metrics/ClassLength
     Receipts::Invoice.new(
       title: I18n.t('factura'),
       details: [
-        [I18n.t('factura') + ' #', display_number || invoice_number],
+        [I18n.t('factura') + ' #', display_number],
         [I18n.t('fecha'), date.strftime('%B %d, %Y')],
         [I18n.t('fecha_vencimiento'), due_date.strftime('%B %d, %Y')],
         [I18n.t('estatus'), "<b><color rgb='#5eba7d'>#{status.upcase}</color></b>"]

--- a/app/views/invoices/_form.html.erb
+++ b/app/views/invoices/_form.html.erb
@@ -28,7 +28,7 @@
           <% elsif invoice.draft? %>
             <span class="form-input w-full pl-8 text-slate-500"><%= t("Borrador") %></span>
           <% else %>
-            <span class="form-input w-full pl-8"><%= invoice.display_number || invoice.invoice_number %></span>
+            <span class="form-input w-full pl-8"><%= invoice.display_number %></span>
           <% end %>
         </div>
       </div>

--- a/db/migrate/20260721204020_remove_invoice_number_from_invoices.rb
+++ b/db/migrate/20260721204020_remove_invoice_number_from_invoices.rb
@@ -1,0 +1,5 @@
+class RemoveInvoiceNumberFromInvoices < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :invoices, :invoice_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_21_201249) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_21_204020) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -55,7 +55,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_21_201249) do
   end
 
   create_table "invoices", force: :cascade do |t|
-    t.string "invoice_number"
     t.datetime "date"
     t.datetime "due_date"
     t.decimal "subtotal", default: "0.0"

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -77,7 +77,6 @@ end
 
 100.times do |i|
   Invoice.create(
-    invoice_number: i,
     date: Faker::Date.between(from: 30.days.ago, to: Date.today),
     due_date: Faker::Date.forward(days: 30),
     notes: Faker::Lorem.paragraph(sentence_count: 2, supplemental: false, random_sentences_to_add: 4),

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -121,10 +121,10 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
 
     post invoices_url,
          params: {
+           save_and_issue: true,
            invoice: {
              date: Date.today,
              due_date: Date.today + 30,
-             status: 'pendiente',
              subtotal: 100,
              iva: 21,
              total: 121,
@@ -145,10 +145,10 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
 
     post invoices_url,
          params: {
+           save_and_issue: true,
            invoice: {
              date: 1.year.ago,
              due_date: Date.today + 30,
-             status: 'pendiente',
              subtotal: 100,
              iva: 21,
              total: 121,

--- a/test/fixtures/invoices.yml
+++ b/test/fixtures/invoices.yml
@@ -1,7 +1,6 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-    invoice_number: '100'
     date: <%= Faker::Date.between(from: 30.days.ago, to: Date.today) %>
     due_date: <%= Faker::Date.forward(days: 30) %>
     notes: <%= Faker::Lorem.sentence(word_count: 20) %>
@@ -16,7 +15,6 @@ one:
     number: 100
 
 two:
-    invoice_number: '101'
     date: <%= Faker::Date.between(from: 30.days.ago, to: Date.today) %>
     due_date: <%= Faker::Date.forward(days: 30) %>
     notes: <%= Faker::Lorem.sentence(word_count: 20) %>
@@ -31,7 +29,6 @@ two:
     number: 101
 
 three:
-    invoice_number: '102'
     date: <%= Faker::Date.between(from: 30.days.ago, to: Date.today) %>
     due_date: <%= Faker::Date.forward(days: 30) %>
     notes: <%= Faker::Lorem.sentence(word_count: 20) %>

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -191,4 +191,25 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_not invoice.valid?
     assert invoice.errors[:status].any?
   end
+
+  test "issued scope excludes drafts" do
+    assert_includes Invoice.issued, invoices(:one)
+    assert_not_includes Invoice.issued, invoices(:draft_one)
+  end
+
+  test "total_invoice_count excludes drafts" do
+    expected = Invoice.where.not(status: 'borrador').count
+    assert_equal expected, Invoice.total_invoice_count
+    assert_equal Invoice.count - Invoice.total_draft_count, Invoice.total_invoice_count
+  end
+
+  test "total_due_count excludes drafts" do
+    expected = Invoice.where.not(status: 'borrador').where('due_date <= ?', Date.today).count
+    assert_equal expected, Invoice.total_due_count
+  end
+
+  test "total_about_to_be_due_count excludes drafts" do
+    expected = Invoice.where.not(status: 'borrador').where('due_date = ?', Date.tomorrow).count
+    assert_equal expected, Invoice.total_about_to_be_due_count
+  end
 end


### PR DESCRIPTION
## What

Completes the expand–contract finish for the invoice numbering ADR: dashboard and list counts now exclude drafts, and the legacy string `invoice_number` column is dropped from the schema.

## Changes

### Draft exclusion
- Added `Invoice.issued` scope (`where.not(status: 'borrador')`)
- `total_invoice_count`, `total_due_count`, `total_about_to_be_due_count` now exclude drafts
- `InvoicesChart` and `PaidVsUnpaidChart` exclude drafts from their queries

### Legacy column removal
- Migration drops `invoice_number` string column from `invoices`
- Removed `|| invoice_number` fallback from PDF rendering and form view — `display_number` (`A-0042`) is the only rendering path
- Cleaned `invoice_number` from fixtures and seeds

### Bug fixes
- Fixed `issue!` calling nonexistent `assign_number_from_default_scope!` → now calls `assign_number!`
- Added `series_id` to permitted params so series selection at invoice creation works

## Acceptance criteria

- [x] Dashboard unpaid/paid/overdue-style counts exclude Drafts; verified by tests
- [x] Legacy string `invoice_number` column removed via migration; schema clean
- [x] No remaining references to the legacy column in models, controllers, views, helpers, search scopes, or locales
- [x] Composed Number display (`A-0042`) is the only rendering path
- [x] Full test suite green (95 tests, 241 assertions, 0 failures)

Closes #35