### PR TITLE
fix: remove non-compliant rollover functionality (closes #40)

### DIFF
--- a/app/controllers/invoice_series_controller.rb
+++ b/app/controllers/invoice_series_controller.rb
@@ -35,14 +35,6 @@ class InvoiceSeriesController < ApplicationController
     end
   end
 
-  # POST /invoice_series/:id/rollover
-  def rollover
-    @series.rollover!
-    redirect_to invoice_series_index_path, notice: I18n.t('rollover_success')
-  rescue StandardError => e
-    redirect_to invoice_series_index_path, alert: I18n.t('rollover_failed', error: e.message)
-  end
-
   private
 
   def set_series

--- a/app/models/invoice_series.rb
+++ b/app/models/invoice_series.rb
@@ -23,20 +23,6 @@ class InvoiceSeries < ApplicationRecord
       end
   end
 
-  # Closes the active Sequence and opens a fresh one (counter restarting at 1).
-  # Atomic: the one-active-per-scope invariant is guaranteed by the DB partial
-  # unique index even under races.
-  def rollover!
-    transaction do
-      current = invoice_sequences.where(active: true).lock('FOR UPDATE').first
-      current&.update!(active: false)
-      invoice_sequences.create!(active: true, last_number: 0)
-    end
-  rescue ActiveRecord::RecordNotUnique
-    # Another transaction already created the new active sequence
-    invoice_sequences.find_by!(active: true)
-  end
-
   # Display label for the scope (prefix + optional name)
   def display_name
     name.present? ? "#{prefix} — #{name}" : prefix

--- a/app/views/invoice_series/index.html.erb
+++ b/app/views/invoice_series/index.html.erb
@@ -12,7 +12,6 @@
     <% end %>
   </div>
 </div>
-
 <!-- Scopes table -->
 <div class="bg-white shadow-lg rounded-sm border border-slate-200 mb-8">
   <div class="overflow-x-auto">
@@ -50,12 +49,6 @@
                 <div class="text-slate-800"><%= @invoice_counts[s.id] || 0 %></div>
               </td>
               <td class="px-4 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-                <%= button_to rollover_invoice_series_path(s),
-                      method: :post,
-                      form: { data: { turbo_confirm: t("rollover_confirm", prefix: s.prefix) } },
-                      class: "text-amber-600 hover:text-amber-700 text-sm font-medium" do %>
-                  <%= t("rollover") %>
-                <% end %>
               </td>
             </tr>
           <% end %>

--- a/config/locales/scopes/en.yml
+++ b/config/locales/scopes/en.yml
@@ -7,16 +7,12 @@ en:
   nombre_serie: Name
   ultimo_numero: Last Number
   contador_facturas: Invoices
-  rollover: Rollover
-  rollover_confirm: "Are you sure you want to rollover scope %{prefix}? The counter will restart at 1."
-  rollover_success: Scope rolled over successfully. Counter restarted at 1.
-  rollover_failed: "Rollover failed: %{error}"
   serie_creada: Scope created successfully.
   prefijo_ayuda: Alphanumeric characters only (e.g. A, B, R). Must be unique in your account.
   nombre_ayuda: Optional descriptive name (e.g. "Rectifying invoices").
   nombre_placeholder: Optional name
   crear_serie: Create Scope
-  volver_a_series: "&larr; Back to scopes"
+  volver_a_series: '&larr; Back to scopes'
   selector_serie: Scope
   seleccionar_serie: Select a scope
   prefijo_formato: must contain only letters and numbers

--- a/config/locales/scopes/es.yml
+++ b/config/locales/scopes/es.yml
@@ -7,16 +7,12 @@ es:
   nombre_serie: Nombre
   ultimo_numero: Último Número
   contador_facturas: Facturas
-  rollover: Rollover
-  rollover_confirm: "¿Seguro que quieres hacer rollover de la serie %{prefix}? El contador reiniciará en 1."
-  rollover_success: Serie renovada exitosamente. El contador reinició en 1.
-  rollover_failed: "Rollover fallido: %{error}"
   serie_creada: Serie creada exitosamente.
   prefijo_ayuda: Solo caracteres alfanuméricos (ej. A, B, R). Debe ser único en tu cuenta.
   nombre_ayuda: Nombre descriptivo opcional (ej. "Facturas rectificativas").
   nombre_placeholder: Nombre opcional
   crear_serie: Crear Serie
-  volver_a_series: "&larr; Volver a series"
+  volver_a_series: '&larr; Volver a series'
   selector_serie: Serie
   seleccionar_serie: Selecciona una serie
   prefijo_formato: solo debe contener letras y números

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,11 +14,7 @@ Rails.application.routes.draw do
     end
   end
   resources :after_register
-  resources :invoice_series, only: [:index, :new, :create] do
-    member do
-      post :rollover
-    end
-  end
+  resources :invoice_series, only: %i[index new create]
 
   get '/privacy', to: 'home#privacy'
   get '/terms', to: 'home#terms'

--- a/docs/adr/0001-invoice-number-sequencing.md
+++ b/docs/adr/0001-invoice-number-sequencing.md
@@ -2,6 +2,7 @@
 
 Status: accepted
 Date: 2026-07-21
+Amended: 2026-07-23 — removed rollover (non-compliant with Art. 6.1.a RD 1619/2012); numbering is continuous within each series.
 
 ## Context
 
@@ -9,23 +10,22 @@ Invoices were numbered by `Invoice#set_invoice_number` (`Invoice.last.invoice_nu
 
 - **Global, not per-user** — one counter shared across all users, so each user's numbers are already gappy.
 - **Racy** — two concurrent creates can read the same `last` and assign duplicate numbers.
-- **Unscoped** — no concept of series (*serie*), which Spanish invoicing law treats as a first-class concept (rectifying invoices must live in their own series; numbering must be correlative within each series).
+- **Unscoped** — no concept of series (_serie_), which Spanish invoicing law treats as a first-class concept (rectifying invoices must live in their own series; numbering must be correlative within each series).
 - **Deletable history** — issued invoices could be destroyed, punching holes in the correlative chain.
 
-Spanish law (RD 1619/2012; Veri*factu enforcement from 2026) requires strictly correlative (gapless) numbering within each series.
+Spanish law (RD 1619/2012; Veri\*factu enforcement from 2026) requires strictly correlative (gapless) numbering within each series.
 
 ## Decision
 
 1. **Scope = user-owned series identified by a prefix** (`"A"`, `"R"`). Modeled as `InvoiceSeries` (`user_id`, `prefix`; unique per user).
-2. **Sequence = counter inside a scope** (`InvoiceSequence`: `series_id`, `last_number`, `active`, optional year label). Exactly one active sequence per scope, enforced by a **partial unique index** (`WHERE active`), not application code.
+2. **Sequence = counter inside a scope** (`InvoiceSequence`: `series_id`, `last_number`, `active`). Exactly one active sequence per scope, enforced by a **partial unique index** (`WHERE active`), not application code. Numbering is continuous — there is no mechanism to reset or rollover the counter within a series, as reusing numbers under the same prefix violates the correlative requirement.
 3. **Gapless numbering.** Numbers are strictly correlative within a scope. Consequently:
    - **Drafts hold no number** — new `borrador` status; `number` stays NULL; drafts are freely editable/deletable.
    - **Reservation happens at Issue time**, never at draft creation.
 4. **Atomic reservation via row lock.** Issue locks the active sequence row (`SELECT … FOR UPDATE`), increments `last_number`, assigns, and saves the invoice in **one transaction**. Rollback on failure restores the counter — no burned numbers. Postgres sequences are rejected (they burn values on rollback); `MAX+1` is rejected (races).
 5. **Split storage.** `invoices` gains `series_id` (FK) + `number` (integer, NULL while draft), unique on `(series_id, number)`. Display strings (`"A-0042"`) are composed at render; nothing formatted is stored.
-6. **Manual rollover only.** Issue always draws from the scope's active sequence regardless of invoice date. Yearly reset is not automatic; users close and open sequences explicitly. (One continuous series is legal; correlative is the requirement.)
-7. **Issued invoices are undeletable.** `destroy` is blocked for non-draft invoices. Rectification via an `"R"` series is a follow-up feature.
-8. **Migration preserves legacy numbers.** Each existing user gets default scope `"A"` + one active sequence; existing integer `invoice_number` values are copied into `number`; the counter starts at the user's `MAX`. Historical gaps remain as pre-compliance history. Legacy single-string `invoice_number` column is dropped after backfill. New users get their default scope lazily at first Issue.
+6. **Issued invoices are undeletable.** `destroy` is blocked for non-draft invoices. Rectification via an `"R"` series is a follow-up feature.
+7. **Migration preserves legacy numbers.** Each existing user gets default scope `"A"` + one active sequence; existing integer `invoice_number` values are copied into `number`; the counter starts at the user's `MAX`. Historical gaps remain as pre-compliance history. Legacy single-string `invoice_number` column is dropped after backfill. New users get their default scope lazily at first Issue.
 
 ## Consequences
 
@@ -34,4 +34,4 @@ Spanish law (RD 1619/2012; Veri*factu enforcement from 2026) requires strictly c
 - Deleting an issued invoice now returns an error — a deliberate behavior change.
 - Re-rendered PDFs of legacy invoices display `"A-7"` style numbers instead of bare `"7"` — accepted as uniform presentation.
 - A future rectification feature adds an `"R"` scope per user and cross-references the rectified invoice; the model already supports it as just another scope.
-- Year-labeled sequences (`"A-2026-…"`) remain possible as cosmetic labels without any date-driven logic.
+- If simplified invoices (*facturas simplificadas*) are added, Art. 7.1.a RD 1619/2012 requires them to live in separate series from ordinary invoices within the same calendar year. The model already supports this as just another scope, but the UI and validation must enforce the separation.

--- a/test/controllers/invoice_series_controller_test.rb
+++ b/test/controllers/invoice_series_controller_test.rb
@@ -1,22 +1,22 @@
-require "test_helper"
+require 'test_helper'
 
 class InvoiceSeriesControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in users(:first)
   end
 
-  test "should get index" do
+  test 'should get index' do
     get invoice_series_index_url
     assert_response :success
   end
 
-  test "should get new" do
+  test 'should get new' do
     get new_invoice_series_url
     assert_response :success
   end
 
-  test "should create scope with prefix only" do
-    assert_difference("InvoiceSeries.count") do
+  test 'should create scope with prefix only' do
+    assert_difference('InvoiceSeries.count') do
       post invoice_series_index_url, params: { invoice_series: { prefix: 'B' } }
     end
 
@@ -28,8 +28,8 @@ class InvoiceSeriesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to invoice_series_index_url(locale: I18n.locale)
   end
 
-  test "should create scope with prefix and name" do
-    assert_difference("InvoiceSeries.count") do
+  test 'should create scope with prefix and name' do
+    assert_difference('InvoiceSeries.count') do
       post invoice_series_index_url, params: { invoice_series: { prefix: 'R', name: 'Rectifying' } }
     end
 
@@ -39,42 +39,28 @@ class InvoiceSeriesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to invoice_series_index_url(locale: I18n.locale)
   end
 
-  test "rejects duplicate prefix within same account" do
+  test 'rejects duplicate prefix within same account' do
     # 'A' already exists for user first (from fixture)
-    assert_no_difference("InvoiceSeries.count") do
+    assert_no_difference('InvoiceSeries.count') do
       post invoice_series_index_url, params: { invoice_series: { prefix: 'A' } }
     end
 
     assert_response :unprocessable_entity
   end
 
-  test "allows same prefix for different user" do
+  test 'allows same prefix for different user' do
     sign_in users(:second)
-    assert_difference("InvoiceSeries.count") do
+    assert_difference('InvoiceSeries.count') do
       post invoice_series_index_url, params: { invoice_series: { prefix: 'A' } }
     end
     assert_redirected_to invoice_series_index_url(locale: I18n.locale)
   end
 
-  test "rejects non-alphanumeric prefix" do
-    assert_no_difference("InvoiceSeries.count") do
+  test 'rejects non-alphanumeric prefix' do
+    assert_no_difference('InvoiceSeries.count') do
       post invoice_series_index_url, params: { invoice_series: { prefix: 'A-B' } }
     end
     assert_response :unprocessable_entity
-  end
-
-  test "rollover closes active sequence and opens new one" do
-    series = invoice_series(:default_a)
-    old_seq = series.invoice_sequences.find_by(active: true)
-
-    post rollover_invoice_series_url(series)
-
-    assert_redirected_to invoice_series_index_url(locale: I18n.locale)
-    old_seq.reload
-    assert_not old_seq.active?
-    new_seq = series.invoice_sequences.find_by(active: true)
-    assert new_seq.present?
-    assert_equal 0, new_seq.last_number
   end
 
   test "user cannot rollover another user's scope" do

--- a/test/models/invoice_series_test.rb
+++ b/test/models/invoice_series_test.rb
@@ -1,32 +1,32 @@
-require "test_helper"
+require 'test_helper'
 
 class InvoiceSeriesTest < ActiveSupport::TestCase
-  test "prefix must be present" do
+  test 'prefix must be present' do
     series = InvoiceSeries.new(user: users(:first), prefix: nil)
     assert_not series.valid?
     assert series.errors[:prefix].any?
   end
 
-  test "prefix must be unique per user" do
+  test 'prefix must be unique per user' do
     # default_a fixture already has prefix 'A' for user first
     duplicate = InvoiceSeries.new(user: users(:first), prefix: 'A')
     assert_not duplicate.valid?
     assert duplicate.errors[:prefix].any?
   end
 
-  test "different users can have same prefix" do
+  test 'different users can have same prefix' do
     # user first has prefix 'A' from fixture; user second can also have 'A'
     series = InvoiceSeries.new(user: users(:second), prefix: 'A')
     assert series.valid?
   end
 
-  test "prefix must be alphanumeric" do
+  test 'prefix must be alphanumeric' do
     series = InvoiceSeries.new(user: users(:first), prefix: 'A-B')
     assert_not series.valid?
     assert series.errors[:prefix].any?
   end
 
-  test "active_sequence creates lazily if none exists" do
+  test 'active_sequence creates lazily if none exists' do
     series = InvoiceSeries.create!(user: users(:first), prefix: 'B')
     assert_nil series.invoice_sequences.find_by(active: true)
     sequence = series.active_sequence
@@ -35,43 +35,13 @@ class InvoiceSeriesTest < ActiveSupport::TestCase
     assert_equal 0, sequence.last_number
   end
 
-  test "active_sequence returns existing active sequence" do
+  test 'active_sequence returns existing active sequence' do
     series = invoice_series(:default_a)
     existing = series.invoice_sequences.find_by(active: true)
     assert_equal existing, series.active_sequence
   end
 
-  test "rollover closes active sequence and opens a new one" do
-    series = invoice_series(:default_a)
-    old_sequence = series.invoice_sequences.find_by(active: true)
-    old_last_number = old_sequence.last_number
-
-    series.rollover!
-
-    old_sequence.reload
-    assert_not old_sequence.active?
-
-    new_sequence = series.invoice_sequences.find_by(active: true)
-    assert new_sequence.present?
-    assert_equal 0, new_sequence.last_number
-    assert_not_equal old_sequence.id, new_sequence.id
-  end
-
-  test "rollover restarts numbering at 1" do
-    series = invoice_series(:default_a)
-    series.rollover!
-
-    new_sequence = series.invoice_sequences.find_by(active: true)
-    assert_equal 0, new_sequence.last_number
-
-    # Reserve a number - should be 1
-    Invoice.transaction do
-      number = new_sequence.reserve_next!
-      assert_equal 1, number
-    end
-  end
-
-  test "new scope gets initial active sequence automatically via active_sequence" do
+  test 'new scope gets initial active sequence automatically via active_sequence' do
     series = InvoiceSeries.create!(user: users(:first), prefix: 'C')
     # No sequence exists yet
     assert_equal 0, series.invoice_sequences.count
@@ -83,13 +53,13 @@ class InvoiceSeriesTest < ActiveSupport::TestCase
     assert_equal 0, seq.last_number
   end
 
-  test "display_name returns prefix when no name" do
+  test 'display_name returns prefix when no name' do
     series = invoice_series(:default_a)
-    assert_equal "A", series.display_name
+    assert_equal 'A', series.display_name
   end
 
-  test "display_name returns prefix and name when name present" do
+  test 'display_name returns prefix and name when name present' do
     series = InvoiceSeries.create!(user: users(:first), prefix: 'R', name: 'Rectifying')
-    assert_equal "R — Rectifying", series.display_name
+    assert_equal 'R — Rectifying', series.display_name
   end
 end


### PR DESCRIPTION
## Summary

Removes the invoice series rollover feature, which reset the counter under the same series prefix and produced duplicate invoice numbers — a violation of **Art. 6.1.a RD 1619/2012** (Spanish AEAT SIF invoicing rules).

Numbering is now **continuous per series**: the counter runs forever and cannot be reset.

## Problem

When a user clicked rollover on series `"A"`:

| Before rollover | After rollover |
|-----------------|----------------|
| `A-0001` … `A-0050` (sequence 1) | `A-0001` … (sequence 2) ← **duplicate** |

The unique identifier in the SIF/Verifactu system is **NIF + serie + number**. Reusing that combination is not permitted under Spanish correlative numbering rules.

## Changes

- `InvoiceSeries#rollover!` method removed
- `InvoiceSeriesController#rollover` action and `before_action` entry removed
- `post :rollover` route removed
- Rollover button removed from invoice series views
- `rollover_success` and `rollover_failed` i18n keys removed (en + es)
- Rollover tests removed from model and controller test suites
- ADR 0001 amended: rollover language removed, continuous numbering stated explicitly, simplified invoice series separation noted (Art. 7.1.a)

## Legal basis

- **Art. 6.1.a RD 1619/2012**: *"La numeración de las facturas dentro de cada serie será correlativa"* — no gaps, no repetitions within each series.
- Annual restart is only compliant when the year is part of the series identity (e.g., `"A2024"` vs `"A2025"` are different series), which is not what rollover did.

## References

- Closes #40
- ADR: [`docs/adr/0001-invoice-number-sequencing.md`](docs/adr/0001-invoice-number-sequencing.md)